### PR TITLE
Revision 2 of the Overwatch License

### DIFF
--- a/overwatch
+++ b/overwatch
@@ -1,4 +1,4 @@
-                     Overwatch License Revision 1
+                     Overwatch License Revision 2
                           (c) Author, year
 
 
@@ -7,8 +7,8 @@ sell the compiled binaries, source code, and documentation (the "Software")
 without attribution.
 
 Permission to modify the Software is only granted to those that have a higher
-competitive matchmaking rank than the copyright holder in Overwatch
-(Blizzard, 2016).
+competitive matchmaking rank than the copyright holder in Overwatch 2
+(Blizzard, 2022).
 
 The Software is provided in the hope that some will find it useful, but the
 Software comes under NO WARRANTY, EXPRESS OR IMPLIED, and the authors of the


### PR DESCRIPTION
[Overwatch is dead](https://gamerant.com/overwatch-servers-shutdown-status-offline/). The servers have been shut down and competitive matchmaking ranks can no longer be viewed for the purposes of this license. This is obviously unacceptable, and it is absolutely critical that this license must have what the kids these days call "usefulness".

Therefore, I have written a Revision 2 to keep the spirit of the license alive with Blizzard's newest ~~mistake~~ ~~greedy cash-grab~~ entry in the Overwatch series, Overwatch 2. This is of course operating under the assumption that Overwatch 2 continues to exist for the next few years despite [everything](https://kotaku.com/overwatch-2-torbjorn-bastion-roster-locked-heroes-bugs-1849640751) [that's](https://mp1st.com/news/overwatch-2-to-earn-one-legendary-skin-requires-over-8-months-of-challenge-grind) [been](https://dotesports.com/overwatch/news/horror-overwatch-2-launch-rolls-on-with-more-issues-as-battle-net-suffers-yet-another-ddos-attack) [going](https://kotaku.com/overwatch-2-beta-tracer-butt-porn-sfm-twitter-blizzard-1848880115) [on](https://www.pcgamer.com/activision-blizzard-exec-who-called-harassment-lawsuit-distorted-and-untrue-steps-down-from-position/) with it since it launched. Whether that's a good assumption or not will have to be seen in the coming years.

_(And yes, this is a shitpost.)_