### PR TITLE
change be gay do crimes link to a permalink

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ UNOFFICIAL LEGAL ADVICE: Don't use these. Like, ever.
   
 * **[Be Gay Do Crimes License](be-gay-do-crimes-license)**
 
-  You have to be gay and do crimes to use this software. [Source](https://github.com/Xe/waifud/blob/main/LICENSE)
+  You have to be gay and do crimes to use this software. [Source](https://github.com/Xe/waifud/blob/44634db21cc3dee925c79b328c60d1962d3bca9c/LICENSE)
 
 * **[sltar License](sltar)**
 


### PR DESCRIPTION
The LICENSE file in the linked repo was swapped for the MIT license 2 years ago, swap for a permalink.