### PR TITLE
Add psi license

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,8 @@ UNOFFICIAL LEGAL ADVICE: Don't use these. Like, ever.
 * **[Gumroad Community License 1.0](gumroad-license.md)**
 
   A "source-available" license that doesn't let you use the software if you make too much money with it. Because the patent protection clause is *also* terminated when you make too much money, you can suddenly become liable for violating patents at any time, and gumroad can now extort you into agreeing to "alternative license terms". [Source](https://github.com/antiwork/gumroad/blob/main/LICENSE.md)
+
+- **[Psi License](psi_license.md)**
+
+  A "license" for a Minecraft mod that doesn't even claim to be enforceable (stating that if you violate it you'd be a "jerk" and "you don't want to be a jerk, do you?"). It claims to be open source, but at the same time does not allow commercial use, and even disallows modification for some parts of the software (the "Psi API"). Supposedly allows redistribution under "similar" copyleft terms, whatever that means.
+  

--- a/README.md
+++ b/README.md
@@ -177,5 +177,5 @@ UNOFFICIAL LEGAL ADVICE: Don't use these. Like, ever.
 
 - **[Psi License](psi_license.md)**
 
-  A "license" for a Minecraft mod that doesn't even claim to be enforceable (stating that if you violate it you'd be a "jerk" and "you don't want to be a jerk, do you?"). It claims to be open source, but at the same time does not allow commercial use, and even disallows modification for some parts of the software (the "Psi API"). Supposedly allows redistribution under "similar" copyleft terms, whatever that means.
+  A "license" for a Minecraft mod that doesn't even claim to be enforceable (stating that if you violate it you'd be a "jerk" and "you don't want to be a jerk, do you?"). It claims to be open source, but at the same time does not allow commercial use, and even disallows modification for some parts of the software (the "Psi API"). Supposedly allows redistribution under "similar" copyleft terms, whatever that means. [Source](https://psi.vazkii.net/license.php)
   

--- a/psi_license.md
+++ b/psi_license.md
@@ -1,0 +1,33 @@
+**Psi is distributed under a reasonably open license. You probably want to have a read through this if you want to do something with it other than just play.**
+You are completely free and have the right to **Use**, **Share** and **Adapt** the mod. These rights can not be removed from you as long as follow the license terms.
+If you simply wish to play with the mod and do nothing else, go for it, this page is of no use to you. 
+
+# General Clauses
+Clauses that apply in general to any of the uses that follow.
+## Personal Permission Clause
+I will not give personal permission unless I know the person asking or there's a really good reason for it, as giving personal permission implies endorsement. Asking for personal permission will likely just end up having you ignored or redirected back to this page.
+## Waive Clause
+All restrictive clauses in this license can be ignored with personal permission. Read the above clause.
+## Extensive Clause
+This license applies to Psi, the Psi website, the legacy Psi website and all other code, assets or binaries found on this website or the github repository unless otherwise indicated.
+## Informal Clause
+This license will not hold up in court. I have no intention of suing anyone for breaking it, the worst that can happen to you if you do is that I'll get annoyed and ask you to rectify your mistake. If you use a public distribution platform (such as CurseForge) it's also possible your project will get taken down. Breaking the license also makes you a jerk, and you don't want to be a jerk, do you?
+# If you want to **Distribute Psi**
+"Distribution" refers to making available binaries, assets, or source of the mod available from the original sources as part of your modpack or otherwise.
+## Attribution Clause
+You must give appropriate credit to Vazkii as the creator of Psi or the parts of it you're using. If you do any alterations the fact that you do so should also be indicated. A link back is optional but it would be cool if you would do so.
+## Non-Monetary Clause
+You may not charge for access to the distribution itself or gain money through it, this includes any type of inline advertisement, such as url shorteners (adf.ly or otherwise) or ads in your service slowing the download down. This includes restricting any amount of access behind a paywall. Charging for ingame goods such as mod items or cosmetic features on a server does not count as distribution and falls purely under the Mojang Terms of Service.
+## If you want to **Feature Psi**
+"Featuring" refers to using Psi in an environment where you do not distribute binaries, assets, or source. An example would be a YouTube Let's Play.
+## Thief Clause
+You must not claim that you made Psi. Giving appropriate credit to Vazkii as the creator of Psi makes you cooler, but you don't have to do it if you don't want to.
+# If you want to **Use Psi Code or Assets**
+Usage of code or assets falls under the Extensive Clause.
+## Attribution Clause
+You must give appropriate credit to Vazkii as the creator of Psi or the parts of it you're using. If you do any alterations the fact that you do so should also be indicated. A link back is optional but it would be cool if you would do so.
+## Copyleft Clause
+Your project must be open source (have its source visible and allow for redistribution and modification) and include a clause similar to this one in its license.
+## API Clause
+Any of the other clauses under this section do not apply to any Psi API code. However, if Psi API code is used, it must be included verbatim as it was obtained. Furthermore, the package-info.java file included with the API must be present, and in the right spot, for any mods that package any compiled API classes within to prevent conflicts.
+*Learn more about the API annotation [here](https://github.com/Minalien/BlogArchive/blob/master/ForgeTutorials/Spotlight__API_Annotation.md).*


### PR DESCRIPTION
I recently saw this "open-source" Minecraft mod called [Psi](https://psi.vazkii.net/) and it has a kind of bizarre [license](https://psi.vazkii.net/license.php) whose its author literally already says is not enforceable.

This license, even if taken informally, just does not qualify as "open-source"; it restricts commercial use and also restricts modification of one part of the software.

I don't know if this is bad enough to be featured here (given the "Informal Clause") but maybe it is?