### PR TITLE
Add CoFH "Don't Be a Jerk" License

### DIFF
--- a/dbaj-license.md
+++ b/dbaj-license.md
@@ -1,0 +1,32 @@
+CoFH "Don't Be a Jerk" License
+====================================
+
+#### Notice
+
+Contribution to this repository means that you are granting us rights over the code that you choose to contribute. If you do not agree with that, do not contribute.
+
+So, why is this here? Well, the rights are reserved, but what that really means is that we choose what to do with the rights. So here you go.
+
+#### You CAN
+- Fork and modify the code.
+- Submit Pull Requests to this repository.
+- Copy portions of this code for use in other projects.
+- Write your own code that uses this code as a dependency. (addon mods!)
+
+#### You CANNOT
+- Redistribute this in its entirety as source or compiled code.
+- Create or distribute code which contains 50% or more Functionally Equivalent Statements* from this repository.
+
+#### You MUST
+- Maintain a visible repository of your code which is inspired by, derived from, or copied from this code. Basically, if you use it, pay it forward. You keep rights to your OWN code, but you still must make your source visible.
+- Not be a jerk**. Seriously, if you're a jerk, you can't use this code. That's part of the agreement.
+
+#### Notes, License & Copyright
+
+*A Functionally Equivalent Statement is a code fragment which, regardless of whitespace and object names, achieves the same result within the context of a Minecraft mod or addon. Basically you can't copy the code, rename the variables, add whitespace and say it's different. It's not.
+
+**A jerk is anyone who attempts to or intends to claim partial or total ownership of the original or repackaged code and/or attempts to or intends to redistribute original or repackaged code without prior express written permission from the owners (CoFH).
+
+Essentially, take this and learn from it! Create addon mods that depend on it! If you see something we can improve, tell us. Submit a Pull Request. The one catch: don't steal! A lot of effort has gone into this, and if you were to take this and call it your own, you'd basically be a big jerk.
+
+Don't be a jerk.


### PR DESCRIPTION
Add the infamous "Don't Be a Jerk" license used by [CoFH mods](https://github.com/CoFH/ThermalExpansion-1.12-Legacy/blob/1.12/README.md), as well as (unfortunately) third parties like [Ars-Magica-Legacy](https://github.com/MinecraftschurliMods/Ars-Magica-Legacy).

The license has been extracted from the readme to remove branding text, leaving only the "terms".