### PR TITLE
Add FAMIT License

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,7 @@ UNOFFICIAL LEGAL ADVICE: Don't use these. Like, ever.
 - **[BEER-WARE](BEER-WARE)**
 
   You can do what you want, but when you meet the author, you have to buy them a beer.
+
+* **[FAMIT License](https://github.com/huangxp12/FAMIT/blob/main/LICENSE)**
+
+  An MIT-derivative parody license that adds a single additional "Condition 0" requiring the user to mentally recite a tongue-in-cheek phrase three times before each use of the software. All MIT permissions, conditions, and warranty disclaimer remain intact; the extra condition is clearly satirical and unenforceable in spirit. The LICENSE file itself is released under MIT. [Source](https://github.com/huangxp12/FAMIT)


### PR DESCRIPTION
Adds FAMIT (Fuck Anthropic MIT License), a one-line parody of the MIT License that adds a "Condition 0" requiring the user to mentally recite a tongue-in-cheek phrase three times before each use.

FAMIT preserves all of MIT's permissions, conditions, and warranty disclaimer; the extra condition is clearly satirical and unenforceable in spirit. It fits naturally next to WTFPL, JSON License, YOLO-WTFPL-SEX, and the other MIT-derived parodies already listed.

The FAMIT LICENSE text itself is released under the MIT License (per the source repo's README), so the underlying legal terms are unambiguously open-source; only the "Condition 0" is the joke.

Note: GitHub does not auto-detect FAMIT as a known license, so the repo UI will show "No license" — the LICENSE file is the source of truth.

- Repo: https://github.com/huangxp12/FAMIT
- License text: https://github.com/huangxp12/FAMIT/blob/main/LICENSE